### PR TITLE
[Refactor] PersonalIndex를 ActorNumber로 변경, 점수 합계 로직 변경

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Scene/02_MatchingStandby/PhotonMatchingSceneEventManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/02_MatchingStandby/PhotonMatchingSceneEventManager.cs
@@ -60,14 +60,6 @@ public class PhotonMatchingSceneEventManager : MonoBehaviourPunCallbacks
         PhotonNetwork.CreateRoom(null);
     }
 
-    public override void OnPlayerPropertiesUpdate(Player targetPlayer, Hashtable changedProps)
-    {
-        if (changedProps.ContainsKey("PersonalIndex"))
-        {
-            int newIndex = (int)changedProps["PersonalIndex"];
-            Debug.Log($"Player {targetPlayer.NickName}'s PersonalIndex changed to {newIndex}");
-        }
-    }
     
     /// <summary>
     /// 로비에 성공적으로 접속하였을 때 호출되는 콜백 메서드

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/GoalCollider.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/GoalCollider.cs
@@ -10,7 +10,7 @@ public class GoalCollider : MonoBehaviourPun
         {
             PlayerPhotonController playerPhotonController = col.GetComponent<PlayerPhotonController>();
             playerPhotonController.SendMessageWinTheStage();
-            int playerPersonalIndex = StageDataManager.Instance.PlayerStageIndex;
+            int playerPersonalIndex = PhotonNetwork.LocalPlayer.ActorNumber;
             
             Debug.Log(playerPhotonController.name);
             

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneEventManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneEventManager.cs
@@ -47,23 +47,12 @@ public class PhotonStageSceneEventManager : MonoBehaviourPunCallbacks
 
     private void SetPlayerSpawnPoints()
     {
-        Player player = PhotonNetwork.LocalPlayer;
-        object indexObject;
-
-        if (player.CustomProperties.TryGetValue("PersonalIndex", out indexObject))
-        {
-            int index = (int)indexObject;
-            string filePath = DataManager.SetDataPath(PathLiteral.Prefabs, "Player");
-        
-            Vector3 spawnPoint = _spawnPoints[index];
-            
-            _playerPrefab = PhotonNetwork.Instantiate(filePath, spawnPoint, Quaternion.identity);
-        }
-        else
-        {
-            Debug.LogWarning("Failed to get the player index from custom properties.");
-        }
+        string filePath = DataManager.SetDataPath(PathLiteral.Prefabs, "Player");
+        Vector3 spawnPoint = _spawnPoints[PhotonNetwork.LocalPlayer.ActorNumber];
+    
+        _playerPrefab = PhotonNetwork.Instantiate(filePath, spawnPoint, Quaternion.identity);
     }
+
     
     private void OnInitializeLoadScene(Scene scene, LoadSceneMode mode)
     {

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Cysharp.Threading.Tasks;
 using LiteralRepository;
 using Photon.Pun;
@@ -47,13 +49,43 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
                 int playerIndex = StageDataManager.Instance.StagePlayerRankings[i];
                 if (StageDataManager.Instance.PlayerScoresByIndex.ContainsKey(playerIndex))
                 {
-                    int oldScore = StageDataManager.Instance.PlayerScoresByIndex[playerIndex];
+                    PlayerData playerData = StageDataManager.Instance.PlayerScoresByIndex[playerIndex];
+                    int oldScore = playerData.Score;
                     int newScore = oldScore + rewards[i];
-                    StageDataManager.Instance.PlayerScoresByIndex[playerIndex] = newScore;
+                    playerData.Score = newScore;
+                    StageDataManager.Instance.PlayerScoresByIndex[playerIndex] = playerData; // Updated PlayerData back to dictionary
                 }
             }
         }
-        
+
+        UpdatePlayerRanking(); 
         StageDataManager.Instance.StagePlayerRankings.Clear();
+
+        // RPC를 호출하여 모든 클라이언트에게 StageDataManager를 업데이트하도록 요청
+        photonView.RPC
+            ("UpdateStageDataOnAllClients", RpcTarget.All, StageDataManager.Instance.PlayerScoresByIndex, StageDataManager.Instance.CachedPlayerIndicesForResults, StageDataManager.Instance.StagePlayerRankings);
+    }
+
+    private void UpdatePlayerRanking()
+    {
+        // PlayerData에 저장된 점수를 기준으로 플레이어를 정렬하고 그 순서대로 인덱스를 CachedPlayerIndicesForResults에 저장
+        var sortedPlayers = 
+            StageDataManager.Instance.PlayerScoresByIndex.OrderByDescending(pair => pair.Value.Score).ToList();
+
+        StageDataManager.Instance.CachedPlayerIndicesForResults.Clear();
+
+        foreach (var pair in sortedPlayers)
+        {
+            StageDataManager.Instance.CachedPlayerIndicesForResults.Add(pair.Key);
+        }
+    }
+
+ 
+    [PunRPC]
+    public void UpdateStageDataOnAllClients(Dictionary<int, PlayerData> playerScoresByIndex, List<int> playerRanking, List<int> stagePlayerRankings)
+    {
+        StageDataManager.Instance.PlayerScoresByIndex = playerScoresByIndex;
+        StageDataManager.Instance.CachedPlayerIndicesForResults = playerRanking;
+        StageDataManager.Instance.StagePlayerRankings = stagePlayerRankings;
     }
 }

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/StageDataManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/StageDataManager.cs
@@ -1,8 +1,7 @@
 using System.Collections.Generic;
-using Photon.Pun;
 using UnityEngine;
 using UniRx;
-using Hashtable = ExitGames.Client.Photon.Hashtable;
+using UnityEngine.Serialization;
 
 public class StageDataManager : SingletonMonoBehaviour<StageDataManager>
 {
@@ -10,20 +9,13 @@ public class StageDataManager : SingletonMonoBehaviour<StageDataManager>
     private ReactiveProperty<bool> _isGameActive = new ReactiveProperty<bool>(false);
     public IReactiveProperty<bool> IsGameActive => _isGameActive;
 
-    // 로컬 플레이어가 자신의 인덱스를 기록하는 객체입니다.    
-    public int PlayerStageIndex;
     // 플레이어의 점수들이 계속해서 저장되는 딕셔너리입니다.
-    public Dictionary<int, int> PlayerScoresByIndex;
+    public Dictionary<int, PlayerData> PlayerScoresByIndex = new Dictionary<int, PlayerData>();
+    // 결과 창에서 사용될 플레이어의 인덱스를 캐싱해놓는 리스트입니다.
+    public List<int> CachedPlayerIndicesForResults = new List<int>();
     // 스테이지에서 사용될 순위를 기록하는 리스트입니다.
     // 스테이지가 넘어갈 때, 초기화됩니다.
     public List<int> StagePlayerRankings;
-    
-    protected override void Awake()
-    {
-        base.Awake();
-        
-        GetPlayerIndex();
-    }
     
     public void AddPlayerToRanking(int playerIndex)
     {
@@ -35,17 +27,6 @@ public class StageDataManager : SingletonMonoBehaviour<StageDataManager>
         }
     }
 
-    private void GetPlayerIndex()
-    {
-        Photon.Realtime.Player localPlayer = PhotonNetwork.LocalPlayer;
-        Hashtable playerProperties = localPlayer.CustomProperties;
-
-        if (playerProperties.TryGetValue("PersonalIndex", out object personalIndexObj))
-        {
-            PlayerStageIndex = (int)personalIndexObj;
-        }
-    }
-    
     /// <summary>
     /// 게임 상태를 변경하는 메소드입니다.
     /// </summary>

--- a/JKC_Fallguys/Assets/Jinsoo/HoopTask.unity
+++ b/JKC_Fallguys/Assets/Jinsoo/HoopTask.unity
@@ -138,7 +138,7 @@ PrefabInstance:
     - target: {fileID: 5634015955707145442, guid: c7a754da359cb49759d8ee76bd50c19b,
         type: 3}
       propertyPath: m_RootOrder
-      value: 3
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 5634015955707145442, guid: c7a754da359cb49759d8ee76bd50c19b,
         type: 3}
@@ -202,6 +202,7 @@ GameObject:
   m_Component:
   - component: {fileID: 483822508}
   - component: {fileID: 483822509}
+  - component: {fileID: 483822510}
   m_Layer: 0
   m_Name: HoopController
   m_TagString: Untagged
@@ -216,13 +217,13 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 483822507}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_Father: {fileID: 1251660733252377209}
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &483822509
 MonoBehaviour:
@@ -236,6 +237,28 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d283a9d557ad14ef3891e25fbce32d1b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &483822510
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 483822507}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 4
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &548488184
 GameObject:
   m_ObjectHideFlags: 0
@@ -412,7 +435,7 @@ PrefabInstance:
     - target: {fileID: 122906925103003174, guid: 0365c497af6a1442bbb9c3b50f6b9ebd,
         type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 122906925103003174, guid: 0365c497af6a1442bbb9c3b50f6b9ebd,
         type: 3}
@@ -6277,6 +6300,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1251660733252377209}
+  - component: {fileID: 1251660733252377210}
   m_Layer: 0
   m_Name: Legend_Hoop_Map
   m_TagString: Untagged
@@ -6304,9 +6328,32 @@ Transform:
   - {fileID: 5919623316694486380}
   - {fileID: 7989692318115412537}
   - {fileID: 550300277}
+  - {fileID: 483822508}
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1251660733252377210
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251660733252377208}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 3
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!65 &1251660733309936282
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/JKC_Fallguys/Assets/Jinsoo/PlayerData.cs
+++ b/JKC_Fallguys/Assets/Jinsoo/PlayerData.cs
@@ -1,0 +1,15 @@
+public class PlayerData
+{
+    public string PlayerName;
+    public int TextureIndex;
+    public int Score;
+    public int Rank;
+    
+    public PlayerData(string playerName, int textureIndex, int score, int rank)
+    {
+        PlayerName = playerName;
+        TextureIndex = textureIndex;
+        Score = score;
+        Rank = rank;
+    }
+}

--- a/JKC_Fallguys/Assets/Jinsoo/PlayerData.cs.meta
+++ b/JKC_Fallguys/Assets/Jinsoo/PlayerData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d03c20618922e41deb13c041009c5f0c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -55,6 +55,9 @@ MonoBehaviour:
   - UpdateTexture
   - SetTextureIndex
   - UpdatePlayerRanking
+  - SendHoopCount
+  - IncreaseCountAndBroadcast
+  - UpdateHoopCount
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 이제 커스텀프로퍼티인 PersonalIndex를 사용하는 자리에, ActorNumber라는 포톤 네트워크의 프로퍼티를 사용하는 로직으로 변경되었습니다
- PlayerData 클래스가 추가되었습니다
- 플레이어 데이터를 가지고 있는 Dictionary가 <int, int>에서 <int, PlayerData>로 변경되었습니다
- 각플레이어의 점수를 계산한 뒤, 랭킹을 업데이트하기 위해 사용될 플레이어의 ActorNumber를 캐싱하는 리스트가 추가되었습니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- PlayerData 클래스가 추가되었습니다
> PlayerName, TextureIndex, Score, Rank의 필드를 가진 클래스이니다
TextureIndexs는 플레이어가 커스텀마이징할 텍스처 인덱스를 정하면, 해당 인덱스를 커스텀프로퍼티로 만든 뒤 입력해줄 예정입니다
Rank는 플레이어의 순위를 캐싱할 리스트가 만들어졌기 떄문에 삭제될 예정입니다
- 커스텀 프로퍼티인 Personal Index를 삭제하였습니다
> 동일한 동작을 수행해 줄 포톤에 내장된 ActorNumber가 존재하여, 로직을 수정하였습니다

# (선택)관련 이슈
- #159 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
