### PR TITLE
[Feat] FruitChute 게임 종료 조건 구현

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Player/PlayerPhotonController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Player/PlayerPhotonController.cs
@@ -24,19 +24,6 @@ public class PlayerPhotonController : MonoBehaviourPunCallbacks, IPunObservable
         _referenceManager = referenceManager;
     }
 
-    [PunRPC]
-    public void AddPlayerToRankingOnGoal(int playerIndex)
-    {
-        // 마스터 클라이언트는 모든 클라이언트에게 순위 업데이트를 요청합니다.
-        photonView.RPC("UpdatePlayerRanking", RpcTarget.All, playerIndex);
-    }
-
-    [PunRPC]
-    public void UpdatePlayerRanking(int playerIndex)
-    {
-        // 각 클라이언트는 이 함수를 통해 자신의 순위 리스트를 최신 상태로 업데이트합니다.
-        StageDataManager.Instance.AddPlayerToRanking(playerIndex);
-    }
     
     private int _textureIndex = 0;
 

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/GoalCollider.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/GoalCollider.cs
@@ -8,13 +8,35 @@ public class GoalCollider : MonoBehaviourPun
     {
         if (col.CompareTag(TagLiteral.Player))
         {
-            PlayerPhotonController playerPhotonController = col.GetComponent<PlayerPhotonController>();
-            int playerPersonalIndex = PhotonNetwork.LocalPlayer.ActorNumber;
+            col.gameObject.transform.root.gameObject.SetActive(false);
+            StageDataManager.Instance.CurrentState.Value = StageDataManager.PlayerState.Victory;
             
-            Debug.Log(playerPhotonController.name);
-            
-            playerPhotonController.photonView.RPC
-                ("AddPlayerToRankingOnGoal", RpcTarget.MasterClient, playerPersonalIndex);
+            photonView.RPC("RpcAddPlayerToRankingOnGoal", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber);
         }
+    }
+    
+    [PunRPC]
+    public void RpcAddPlayerToRankingOnGoal(int playerIndex)
+    {
+        // 마스터 클라이언트는 모든 클라이언트에게 순위 업데이트를 요청합니다.
+        photonView.RPC("RpcUpdatePlayerRanking", RpcTarget.All, playerIndex);
+    }
+
+    [PunRPC]
+    public void RpcUpdatePlayerRanking(int playerIndex)
+    {
+        // 각 클라이언트는 이 함수를 통해 자신의 순위 리스트를 최신 상태로 업데이트합니다.
+        StageDataManager.Instance.AddPlayerToRanking(playerIndex);
+
+        if (StageDataManager.Instance.StagePlayerRankings.Count == 3)
+        {
+            photonView.RPC("RpcEndGameBroadCast", RpcTarget.All);
+        }
+    }
+
+    [PunRPC]
+    public void RpcEndGameBroadCast()
+    {
+        StageDataManager.Instance.SetGameStatus(false);
     }
 }

--- a/JKC_Fallguys/Assets/Jinsoo/FruitChuteController.cs
+++ b/JKC_Fallguys/Assets/Jinsoo/FruitChuteController.cs
@@ -1,0 +1,65 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using Photon.Pun;
+using UniRx;
+using UnityEngine;
+
+public class FruitChuteController : StageController
+{
+    protected override void SetGameTime()
+    {
+        remainingGameTime.Value = 60;
+    }
+
+    protected override void InitializeRx()
+    {
+        StageDataManager.Instance.IsGameActive
+            .Where(state => state)
+            .Subscribe(_ => --remainingGameTime.Value)
+            .AddTo(this);
+
+        remainingGameTime
+            .Subscribe(_ => GameStartBroadCast())
+            .AddTo(this);
+
+        remainingGameTime
+            .Where(count => remainingGameTime.Value == 0)
+            .Subscribe(_ => RpcEndGame())
+            .AddTo(this);
+        
+    }
+    
+    private void GameStartBroadCast()
+    {
+        if (PhotonNetwork.IsMasterClient)
+        {
+            photonView.RPC("RpcCountDown", RpcTarget.All);
+        }
+    }
+
+    [PunRPC]
+    public void RpcCountDown()
+    {
+        --remainingGameTime.Value;
+    }
+
+    private void RpcEndGame()
+    {
+        if (PhotonNetwork.IsMasterClient)
+        {
+            photonView.RPC("RpcEndGame", RpcTarget.All);
+        }
+    }
+
+    [PunRPC]
+    public void EndGame()
+    {
+        StageDataManager.Instance.IsGameActive.Value = false;
+
+        if (StageDataManager.Instance.CurrentState.Value != StageDataManager.PlayerState.Victory)
+        {
+            StageDataManager.Instance.CurrentState.Value = StageDataManager.PlayerState.Defeat;
+        }
+    }
+}

--- a/JKC_Fallguys/Assets/Jinsoo/FruitChuteController.cs.meta
+++ b/JKC_Fallguys/Assets/Jinsoo/FruitChuteController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 94b72f108a6264377b78f955561a4d3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 이제 FruitChute의 게임 종료 조건은, 맵 스스로가 결정합니다
- 3명까지 들어올 경우 맵의 활성화가 꺼지며, 만약 3명이 들어오기 전이라도 맵에 존재하는 플레이어의 인원수가 다 들어왔다면, 게임이 끝납니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- FruitChute의 게임 종료 조건은, 맵 스스로가 결정합니다
> 맵이 생성될 때 FruitChuteController가 판단합니다.
- 3명이 다 들어오지 않는 경우의 예외처리를 해주었습니다
> PhotonNetwork.CurrentRoom.PlayerCount >= StageDataManager.Instance.StagePlayerRankings.Count
조건을 추가하여, 현재 방에 입장한 플레이어의 숫자를 이용하여 체크하는 로직을 추가하였습니다

# (선택)관련 이슈
- #188 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
