### PR TITLE
[Bug] 라운드 종료! UI가 모든 클라이언트에서 뜨지 않는 이슈 해결

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
@@ -63,8 +63,6 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
     // StageDataManager의 IsGameActive가 true => false일 때 호출됩니다.
     private void CompleteStageAndRankPlayers()
     {
-        // Time.timeScale = 0f;
-
         if (!PhotonNetwork.IsMasterClient)
             return;
         
@@ -75,14 +73,18 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
     private async UniTaskVoid PrevEndProduction()
     {
         await UniTask.Delay(TimeSpan.FromSeconds(4f), DelayType.UnscaledDeltaTime);
-        
-        // 게임을 정리하는 로직이 실행 된 뒤, 다음 씬으로 가는 작업을 수행합니다.
-        photonView.RPC("EnterNextScene", RpcTarget.MasterClient);
-        StageDataManager.Instance.SetRoundState(true);
+
+        EnterNextScene();
+        photonView.RPC("SetRoundState", RpcTarget.All);
     }
 
     [PunRPC]
-    public void EnterNextScene()
+    public void SetRoundState()
+    {
+        StageDataManager.Instance.SetRoundState(true);
+    }
+
+    private void EnterNextScene()
     {
         if (!photonView.IsMine)
             return;

--- a/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -80,6 +80,7 @@ MonoBehaviour:
   - RpcSetAxeRotationForce
   - RpcStartOrder
   - TriggerOperation
+  - SetRoundState
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 모든 클라이언트에서 라운드 종료! UI가 뜨지 않는 이슈를 수정하였습니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 모든 클라이언트에서 라운드 종료! UI가 뜨지 않는 이슈를 수정하였습니다
> 마스터 클라이언트의 데이터만 수정하고 있던 코드를, 전체 클라이언트가 데이터를 수정하도록 코드를 변경하였습니다

# (선택)스크린샷
<img width="974" alt="스크린샷 2023-07-03 오후 3 00 33" src="https://github.com/KIA-PROGRAMMING-38/JKC-FallguysProject/assets/120005202/49223adf-6907-4f29-a7e3-b8fc1b7d766a">

# (선택)관련 이슈
- #239 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
