### PR TITLE
[Bug] RoundResult 씬에 진입할 때, PlayerName이 정상적으로 UI와 동기화되지 않는 이슈 해결

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Scene/02_MatchingStandby/PhotonMatchingSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/02_MatchingStandby/PhotonMatchingSceneRoomManager.cs
@@ -4,7 +4,6 @@ using Photon.Pun;
 using Photon.Realtime;
 using UniRx;
 using LiteralRepository;
-using UnityEngine;
 
 /// <summary>
 /// 게임 시작을 관리하는 클래스입니다.
@@ -50,7 +49,7 @@ public class PhotonMatchingSceneRoomManager : MonoBehaviourPun
             // 새로운 PlayerData 객체를 만들고, 이를 PlayerScoresByIndex 딕셔너리에 추가합니다.
             int playerTextureIndex = (int)player.Value.CustomProperties["PlayerTextureIndex"];
             StageDataManager.Instance.PlayerDataByIndex[actorNumber] =
-                new PlayerData(PhotonNetwork.LocalPlayer.NickName, playerTextureIndex, 0);
+                new PlayerData(player.Value.NickName, playerTextureIndex, 0);
         }
     }
 

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
@@ -7,8 +7,6 @@ using Model;
 using Newtonsoft.Json;
 using Photon.Pun;
 using UniRx;
-using UnityEditor.Rendering;
-using UnityEngine;
 
 /// <summary>
 /// 점수를 결산한 뒤 다음 씬을 실행시키는 클래스입니다.
@@ -181,7 +179,7 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
 
         StageDataManager.Instance.CachedPlayerIndicesForResults.Clear();
 
-        foreach (var pair in sortedPlayers)
+        foreach (KeyValuePair<int, PlayerData> pair in sortedPlayers)
         {
             StageDataManager.Instance.CachedPlayerIndicesForResults.Add(pair.Key);
         }

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/StageDataManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/StageDataManager.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using UniRx;
-using UnityEngine;
 
 public class StageDataManager : SingletonMonoBehaviour<StageDataManager>
 {

--- a/JKC_Fallguys/Assets/1_Scripts/System/PhotonCleaner.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/System/PhotonCleaner.cs
@@ -1,4 +1,3 @@
-using UnityEngine;
 using Photon.Pun;
 
 public class PhotonCleaner : MonoBehaviourPun
@@ -8,8 +7,6 @@ public class PhotonCleaner : MonoBehaviourPun
         // IsMine 속성을 사용하여 이 오브젝트가 로컬 플레이어의 것인지 확인합니다.
         if (photonView.IsMine)
         {
-            Debug.Log($"OnDestroy : { gameObject.name }");
-
             // 이 오브젝트를 파괴합니다.
             PhotonNetwork.Destroy(photonView);
         }


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- RoundResult 씬에 진입할 때, PlayerName이 정상적으로 UI와 동기화되지 않는 이슈가 해결되었습니다
- 정상적으로, RoundResult 씬에 진입할 때 순위에 맞는 PlayerName이 출력됩니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- PhotonMatchingSceneRoomManager 클래스를 수정하였습니다
> PlayerData를 저장할 때 PhotonNetwork.LocalPlayer.PlayerName을 입력해선 안됐는데, 이를 변경하였습니다

# (선택)스크린샷
https://github.com/KIA-PROGRAMMING-38/JKC-FallguysProject/assets/120005202/92532cdc-8e0d-4f28-ac40-7563b9c7721c

# (선택)관련 이슈
- #241 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
