### PR TITLE
[Fix] Jump관련 Action메소드 PlayerLoopTiming FixedUpdate로 변경

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Player/Player States/Jump/JumpingState.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Player/Player States/Jump/JumpingState.cs
@@ -7,11 +7,11 @@ public class JumpingState : StateMachineBehaviour
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         _playerPhysicsController = animator.GetComponent<PlayerPhysicsController>();
+        _playerPhysicsController.ActivateOnJumpingAction();
     }
     
-    override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
+    override public void OnStateExit( Animator animator, AnimatorStateInfo stateInfo, int layerIndex )
     {
-        // 공중에서 인풋에 따라 움직일 수 있게 한다.
-        _playerPhysicsController.OnJumping();
+        _playerPhysicsController.jumpCancellationTokenSource.Cancel();
     }
 }

--- a/JKC_Fallguys/Assets/1_Scripts/Player/PlayerPhysicsController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Player/PlayerPhysicsController.cs
@@ -116,6 +116,9 @@ public class PlayerPhysicsController : MonoBehaviourPun
     public CancellationTokenSource jumpCancellationTokenSource;
     CancellationToken _jumpCancellationToken => jumpCancellationTokenSource.Token;
     
+    /// <summary>
+    /// UniTask함수인 OnJumpingAction을 호출하는 함수입니다. JumpingState에서 호출해주세요.
+    /// </summary>
     public void ActivateOnJumpingAction()
     {
         jumpCancellationTokenSource = new CancellationTokenSource();
@@ -149,7 +152,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     }
 
     /// <summary>
-    /// Jump Start State에서 호출.
+    /// UniTask함수인 JumpAction을 호출하는 함수입니다. Jump Start State에서 호출해주세요.
     /// </summary>
     public void ActivateJumpAction()
     {
@@ -167,7 +170,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     }
 
     /// <summary>
-    /// DiveStartState에서 호출.
+    /// UniTask로 구현된 Dive관련 함수들을 호출하는 함수입니다. DiveStartState에서 호출해주세요.
     /// </summary>
     public void ActivateDiveAction()
     {
@@ -184,7 +187,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     private float _diveRotationX = 90;
     [SerializeField] private float _diveRotationSpeed;
     
-    // 캐릭터가 Dive할때 회전하는 함수.
+    // 캐릭터가 Dive할때 회전하는 함수입니다.
     private async UniTaskVoid DiveRotation()
     {
         _playerInput.CannotMove = true;
@@ -194,7 +197,6 @@ public class PlayerPhysicsController : MonoBehaviourPun
         
         while (Quaternion.Angle(transform.rotation, _targetRotation) > 0.1f)
         {
-            // 캐릭터의 원래 방향으로 rotation한다.
             float step = _diveRotationSpeed * Time.deltaTime;
             transform.rotation = Quaternion.RotateTowards(transform.rotation, _targetRotation, step);
             
@@ -208,21 +210,21 @@ public class PlayerPhysicsController : MonoBehaviourPun
     private Vector3 _diveDirection;
     [SerializeField] private float _diveHeightDirection;
     
-    // Dive시 앞으로 힘을 주어 점프하는 함수.
+    // Dive시 앞으로 힘을 주어 움직이게 하는 함수 입니다.
     private async UniTaskVoid DiveAction()
     {
         await UniTask.DelayFrame(3);
         
-        // Player가 바라보고 있는 방향을 구한뒤 Dive Direction을 구한다.
+        // Player가 바라보고 있는 방향을 구한뒤 Dive Direction을 구합니다.
         _playerDirection = transform.forward;
         _diveDirection = new Vector3(_playerDirection.x, _diveHeightDirection, _playerDirection.z);
 
-        // Dive Direction으로 힘을 준다.
+        // Dive Direction으로 힘을 줍니다.
         _playerRigidbody.AddForce(_diveDirection * _diveForce, ForceMode.Impulse);
     }
 
     /// <summary>
-    /// GetUpState에서 호출.
+    /// GetUpState에서 호출해주세요.
     /// </summary>
     public void ActivateGetUp()
     {
@@ -234,7 +236,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     
     [SerializeField] private float _getUpRotationSpeed;
 
-    // 캐릭터가 Dive이후 일어나게 하는 함수.
+    // 캐릭터가 Dive이후 일어나게 하는 함수입니다.
     private async UniTaskVoid GetUp()
     {
         _playerInput.CannotMove = true;
@@ -244,7 +246,6 @@ public class PlayerPhysicsController : MonoBehaviourPun
         
         while (Quaternion.Angle(transform.rotation, _targetRotation) > 0.1f)
         {
-            // 캐릭터의 원래 방향으로 rotation한다.
             float step = _getUpRotationSpeed * Time.deltaTime;
             transform.rotation = Quaternion.RotateTowards(transform.rotation, _targetRotation, step);
             
@@ -255,7 +256,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     }
 
     /// <summary>
-    /// 넘어지면서 회전축을 푸는 함수. Fall State에서 호출.
+    /// 넘어지면서 회전축을 푸는 함수입니다. Fall State에서 호출해주세요.
     /// </summary>
     public void UnfreezeRotationAxis()
     {
@@ -266,7 +267,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     }
 
     /// <summary>
-    /// Recovery State에서 호출.
+    /// Recovery State에서 호출해주세요.
     /// </summary>
     public void ActivateRecovery()
     {
@@ -276,7 +277,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
         Recovery().Forget();
     }
     
-    // 평지에서 Fall 이후 다시 일어나게 하는 함수.
+    // 평지에서 Fall 이후 다시 일어나게 하는 함수입니다.
     private async UniTaskVoid Recovery()
     {
         _playerInput.CannotMove = true;
@@ -290,7 +291,6 @@ public class PlayerPhysicsController : MonoBehaviourPun
 
         while (Quaternion.Angle(transform.rotation, _targetRotation) > 0.1f)
         {
-            // 캐릭터의 원래 방향으로 rotation한다.
             float step = _getUpRotationSpeed * Time.deltaTime;
             transform.rotation = Quaternion.RotateTowards(transform.rotation, _targetRotation, step);
             
@@ -301,7 +301,7 @@ public class PlayerPhysicsController : MonoBehaviourPun
     }
 
     /// <summary>
-    /// Fall 이후 다시 원위치 되는 함수. Respawn Boundary랑 충돌햇을때 호출. 
+    /// Fall 이후 다시 Respawn 되는 함수입니다.. Respawn Boundary랑 충돌햇을때 호출해주세요. 
     /// </summary>
     public void Respawn(Vector3 respawnPos, Quaternion respawnAngle)
     {

--- a/JKC_Fallguys/Assets/Resources/Prefabs/Player.prefab
+++ b/JKC_Fallguys/Assets/Resources/Prefabs/Player.prefab
@@ -954,7 +954,7 @@ MonoBehaviour:
   _groundCheckPoint: {fileID: 2387829583882509454}
   _castRadius: 0.2
   _groundCheckDistance: 3
-  _jumpMovementForce: 40
+  _jumpMovementForce: 300
   _diveRotationSpeed: 300
   _diveHeightDirection: 2
   _getUpRotationSpeed: 300


### PR DESCRIPTION
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 컴퓨터마다 플레이어가 점프시에 동일한 물리연산을 하게 변경했습니다.

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- UniTask의 PlayerLoopTiming 사용
> UniTask.Yield(PlayerLoopTiming.FixedUpdate)를 사용하여 다음 프레임의 FixedUpdate 시점까지 대기하도록 설정하여 정확한 시간 간격으로 반복 작업이 수행될 수 있도록 합니다.

# (선택)스크린샷
이 기능과 관련된 스크린샷을 추가합니다. (동영상 가능)

# (선택)관련 이슈
- #247 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
