### PR TITLE
[Refactor] Stage 씬이 종료될 때, Player를 정리하는 로직 변경

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PhotonStageSceneRoomManager.cs
@@ -123,16 +123,24 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
         }
         
         EndLogic();
-
+        
+        photonView.RPC("RpcEveryClientPhotonViewTransferOwnerShip", RpcTarget.AllBuffered);
         
         StageEndProduction().Forget();
     }
+
+    [PunRPC]
+    public void RpcEveryClientPhotonViewTransferOwnerShip()
+    {
+        StageRepository.Instance.PlayerDispose();
+    }
+    
     
     private async UniTaskVoid StageEndProduction()
     {
         await UniTask.Delay(TimeSpan.FromSeconds(5f), DelayType.UnscaledDeltaTime);
 
-        ClearPlayerObject();
+        photonView.RPC("RpcClearPlayerObject", RpcTarget.MasterClient);
         
         if (StageDataManager.Instance.IsFinalRound())
         {
@@ -144,8 +152,10 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
         }
     }
 
-    private void ClearPlayerObject()
+    [PunRPC]
+    public void RpcClearPlayerObject()
     {
+        
         List<GameObject> children = new List<GameObject>();
 
         foreach (Transform child in StageDataManager.Instance.gameObject.transform)
@@ -164,11 +174,6 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
         
             if (childPhotonView == null || childPhotonView.ViewID < 0)
                 continue;
-        
-            if (!ReferenceEquals(childPhotonView.Owner, PhotonNetwork.MasterClient))
-            {
-                childPhotonView.TransferOwnership(PhotonNetwork.MasterClient.ActorNumber);
-            }
 
             PhotonNetwork.Destroy(childPhotonView);
         }

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PlayerContainer.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/03_Stage/PlayerContainer.cs
@@ -15,8 +15,6 @@ public class PlayerContainer
     
     public void ObservedNextPlayer()
     {
-        Debug.Log($"InitNextPlayer: {_observingList.Count}");
-        
         if (_observingList.Count == 0)
         {
             return;
@@ -25,16 +23,12 @@ public class PlayerContainer
         int startIndex = _observingIndex;
         do
         {
-            Debug.Log($"PrevObservingIndex: {_observingIndex}");
             _observingIndex = (_observingIndex + 1) % _observingList.Count;
-            Debug.Log($"NextObservingIndex: {_observingIndex}");
             
             GameObject current = _observingList[_observingIndex];
-            Debug.Log($"First: {current.name}");
             if (current == null || !current.activeSelf)
                 continue;
 
-            Debug.Log($"Second: {_observingList[_observingIndex].name}");
             Transform character = current.transform.Find("Character");
             if (character == null)
                 continue;
@@ -91,7 +85,6 @@ public class PlayerContainer
             GameObject childObject = childTransform.gameObject;
         
             _observingList.Add(childObject);
-            Debug.Log(childObject.name);
         }
     }
 }

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/FruitChute/FruitChuteController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/FruitChute/FruitChuteController.cs
@@ -29,7 +29,7 @@ public class FruitChuteController : StageController
     
     protected override void SetGameTime()
     {
-        StageSceneModel.SetRemainingTime(60);
+        StageSceneModel.SetRemainingTime(10);
     }
 
     protected override void InitializeRx()

--- a/JKC_Fallguys/Assets/1_Scripts/System/PhotonCleaner.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/System/PhotonCleaner.cs
@@ -1,13 +1,33 @@
+using System;
 using Photon.Pun;
+using UnityEngine;
 
 public class PhotonCleaner : MonoBehaviourPun
 {
+    private void Awake()
+    {
+        StageRepository.Instance.OnPlayerDispose -= TransferPhotonViewOwnership;
+        StageRepository.Instance.OnPlayerDispose += TransferPhotonViewOwnership;
+    }
+
+    private void TransferPhotonViewOwnership()
+    {
+        if (!photonView.IsMine)
+            return;
+        
+        photonView.TransferOwnership(PhotonNetwork.MasterClient.ActorNumber);
+        Debug.Log($"MasterNumber: {PhotonNetwork.MasterClient.ActorNumber}");
+        Debug.Log($"PhotonOwnerAct: {photonView.OwnerActorNr}");
+    }
+
     private void OnDestroy()
     {
         if (photonView.IsMine && gameObject != null)
         {
             photonView.RPC("RpcDestroyOnNetwork", RpcTarget.MasterClient);
         }
+        
+        StageRepository.Instance.OnPlayerDispose -= TransferPhotonViewOwnership;
     }
 
     [PunRPC]

--- a/JKC_Fallguys/Assets/1_Scripts/Util/LiteralRepository/PathLiteral.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Util/LiteralRepository/PathLiteral.cs
@@ -22,6 +22,8 @@ namespace LiteralRepository
 
         public static readonly string RoundMusic = "Round";
         public static readonly string FinalRoundMusic = "FinalRound";
+        public static readonly string AudioMixer = "AudioMixer";
+        
 
         public static readonly string Login = "00_Login";
         public static readonly string Lobby = "01_Lobby";

--- a/JKC_Fallguys/Assets/Jinsoo/StageRepository.cs
+++ b/JKC_Fallguys/Assets/Jinsoo/StageRepository.cs
@@ -1,7 +1,16 @@
+using System;
+
 public class StageRepository : SingletonMonoBehaviour<StageRepository>
 {
+    public event Action OnPlayerDispose;
+    
     public void Initialize()
     {
         
+    }
+
+    public void PlayerDispose()
+    {
+        OnPlayerDispose?.Invoke();        
     }
 }

--- a/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -89,6 +89,8 @@ MonoBehaviour:
   - DestroyOnNetwork
   - RpcDestroyOnNetwork
   - RpcSetParentStageRepository
+  - RpcClearPlayerObject
+  - RpcEveryClientPhotonViewTransferOwnerShip
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1

--- a/JKC_Fallguys/Assets/Resources/Prefabs/Player.prefab
+++ b/JKC_Fallguys/Assets/Resources/Prefabs/Player.prefab
@@ -210,6 +210,7 @@ GameObject:
   - component: {fileID: 122906925103003170}
   - component: {fileID: 1263158404}
   - component: {fileID: -6049000865041229812}
+  - component: {fileID: 6519176588120398172}
   m_Layer: 0
   m_Name: Player
   m_TagString: Player
@@ -385,12 +386,24 @@ MonoBehaviour:
   Group: 0
   prefixField: -1
   Synchronization: 2
-  OwnershipTransfer: 0
+  OwnershipTransfer: 1
   observableSearch: 2
   ObservedComponents: []
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
+--- !u!114 &6519176588120398172
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 122906925103003175}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3e4a9d4b0af0b468b911d2f28904ca1c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &203718135387862326
 GameObject:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 스테이지 씬이 정리되는 로직이 실행될 경우, 플레이어의 소유권을 마스터 클라이언트에게 넘깁니다
- 마스터 클라이언트에게 넘긴 후, 마스터 클라이언트는 모든 PhotonNetwork.Instantiate한 객체를 정리합니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 마스터 클라이언트가 모든 정리를 담당합니다

# (선택)스크린샷
https://github.com/KIA-PROGRAMMING-38/JKC-FallguysProject/assets/120005202/0cd53cec-0ec4-4c2a-bf98-c540ccd3ddaf

# (선택)관련 이슈
- #280 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
