### PR TITLE
[Bug] HoopLegend맵에서 마스터 클라이언트가 아닌 클라이언트가 후프를 통과했을 때, 마스터 클라이언트도 점수를 얻는 현상 수정

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/CommonHoop.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/CommonHoop.cs
@@ -126,5 +126,7 @@ public class CommonHoop : MonoBehaviourPun
     {
         _goalCheck.OnPlayerEnter -= HandlePlayerEnter;
         _goalCheck.OnPlayerExit -= HandlePlayerExit;
+        
+        _cancelToken.Cancel();
     }
 }

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/HoopController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/HoopController.cs
@@ -10,14 +10,12 @@ public class HoopController : MonoBehaviourPun
 {
     private Dictionary<int, int> _playerHoopCounts = new Dictionary<int, int>();
     private HoopLegendController _hoopLegendController;
-    private CancellationTokenSource _cancellationToken;
     
     private void Awake()
     {
         StageRepository.Instance.SetHoopControllerReference(this);
         _hoopLegendController = GetComponentInParent<HoopLegendController>();
         Debug.Assert(_hoopLegendController != null);
-        _cancellationToken = new CancellationTokenSource();
 
         if (PhotonNetwork.IsMasterClient)
         {
@@ -112,10 +110,5 @@ public class HoopController : MonoBehaviourPun
     public void PlayerPassesHoop(int value)
     {
         photonView.RPC("IncreaseCountAndBroadcast", RpcTarget.MasterClient, PhotonNetwork.LocalPlayer.ActorNumber, value);
-    }
-
-    private void OnDestroy()
-    {
-        _cancellationToken.Cancel();
     }
 }

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/SpecialHoop.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/SpecialHoop.cs
@@ -126,5 +126,7 @@ public class SpecialHoop : MonoBehaviourPun
     {
         _goalCheck.OnPlayerEnter -= HandlePlayerEnter;
         _goalCheck.OnPlayerExit -= HandlePlayerExit;
+        
+        _cancelToken.Cancel();
     }
 }

--- a/JKC_Fallguys/Assets/Doik/Kimdoik_Working Pole/Legend_Hoop/Scripts_Legend/GoalCheck.cs
+++ b/JKC_Fallguys/Assets/Doik/Kimdoik_Working Pole/Legend_Hoop/Scripts_Legend/GoalCheck.cs
@@ -1,8 +1,9 @@
 using System;
 using LiteralRepository;
+using Photon.Pun;
 using UnityEngine;
 
-public class GoalCheck : MonoBehaviour
+public class GoalCheck : MonoBehaviourPun
 {
     public event Action OnPlayerEnter;
     public event Action OnPlayerExit;
@@ -10,21 +11,29 @@ public class GoalCheck : MonoBehaviour
     private bool _goalInPlayer;
     public bool GoalInPlayer => _goalInPlayer;
 
-    private void OnTriggerEnter(Collider other)
+    private void OnTriggerEnter(Collider col)
     {
-        if (other.CompareTag(TagLiteral.Player))
+        if (col.CompareTag(TagLiteral.Player))
         {
-            _goalInPlayer = true;
-            OnPlayerEnter?.Invoke();
+            PhotonView playerPhotonView = col.GetComponent<PhotonView>();
+            if (playerPhotonView != null && playerPhotonView.IsMine)
+            {
+                _goalInPlayer = true;
+                OnPlayerEnter?.Invoke();
+            }
         }
     }
 
-    private void OnTriggerExit(Collider other)
+    private void OnTriggerExit(Collider col)
     {
-        if (other.CompareTag(TagLiteral.Player))
+        if (col.CompareTag(TagLiteral.Player))
         {
-            _goalInPlayer = false;
-            OnPlayerExit?.Invoke();
+            PhotonView playerPhotonView = col.GetComponent<PhotonView>();
+            if (playerPhotonView != null && playerPhotonView.IsMine)
+            {
+                _goalInPlayer = false;
+                OnPlayerExit?.Invoke();    
+            }
         }
     }
 } 


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- Hoop의 Collider를 지날 때, 이제 자신의 클라이언트 포톤 뷰만 검사합니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 자신의 클라이언트 포톤 뷰만 검사합니다
> 단순히, TagLiteral.Player 로만 검사했을 때는, 마스터 콜라이언트에서도 로직이 실행되었습니다
정상적으로 실행할 클라이언트를 정하기 위해, 조건문을 추가하였습니다

# (선택)관련 이슈
- #285 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
