### PR TITLE
[Feat] 골 콜라이더에 닿거나 데드존에 닿을 경우, 플레이어의 프리팹을 끄는 기능 추가

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Player/PlayerPhotonController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Player/PlayerPhotonController.cs
@@ -16,4 +16,10 @@ public class PlayerPhotonController : MonoBehaviourPunCallbacks
     {
         transform.parent.SetParent(StageDataManager.Instance.gameObject.transform);
     }
+
+    [PunRPC]
+    public void RpcSetDeActivePlayerObject()
+    {
+        transform.parent.gameObject.SetActive(false);
+    }
 }

--- a/JKC_Fallguys/Assets/1_Scripts/Scene/04_GameLoading/MapSelectionManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/04_GameLoading/MapSelectionManager.cs
@@ -10,7 +10,7 @@ public class MapSelectionManager : MonoBehaviourPun
         }
     }
 
-    private int index = 1;
+    private int index = 2;
     private void SelectRandomMap()
     {
         if (PhotonNetwork.IsMasterClient)

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/FruitChute/FruitChuteGoalCollider.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/FruitChute/FruitChuteGoalCollider.cs
@@ -15,6 +15,8 @@ public class FruitChuteGoalCollider : MonoBehaviourPun
 
                 StageDataManager.Instance.SetPlayerState(actorNumber, StageDataManager.PlayerState.Victory);
                 StageDataManager.Instance.SetPlayerActive(actorNumber, false);
+                
+                playerPhotonView.RPC("RpcSetDeActivePlayerObject", RpcTarget.AllBuffered);
         
                 photonView.RPC("RpcAddPlayerToRankingOnGoal", RpcTarget.MasterClient, actorNumber);
             }

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/HoopLegendController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/HoopLegendController.cs
@@ -18,7 +18,7 @@ public class HoopLegendController : StageController
     
     protected override void SetGameTime()
     {
-        StageSceneModel.SetRemainingTime(30);
+        StageSceneModel.SetRemainingTime(60);
     }
 
     protected override void InitializeRx()

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/JumpClub/JumpClubDeadZone.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/JumpClub/JumpClubDeadZone.cs
@@ -17,6 +17,8 @@ public class JumpClubDeadZone : MonoBehaviourPun
                 int actorNumber = PhotonNetwork.LocalPlayer.ActorNumber;
                 StageDataManager.Instance.SetPlayerActive(actorNumber, false);
                 StageDataManager.Instance.SetPlayerState(actorNumber, StageDataManager.PlayerState.Defeat);
+                
+                playerPhotonView.RPC("RpcSetDeActivePlayerObject", RpcTarget.AllBuffered);
 
                 photonView.RPC("RpcAddPlayerToFailedList", RpcTarget.All, actorNumber);
             }

--- a/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/RoundEnd/RoundEndPresenter.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/RoundEnd/RoundEndPresenter.cs
@@ -22,11 +22,11 @@ public class RoundEndPresenter : Presenter
     {
         StageDataManager.Instance.IsRoundCompleted
             .Where(isRoundCompleted => isRoundCompleted)
-            .Subscribe(_ => Test())
+            .Subscribe(_ => UIAction())
             .AddTo(_compositeDisposable);
     }
 
-    private void Test()
+    private void UIAction()
     {
         _roundEndView.RoundEndPanel.MoveUI(_center, _roundEndView.CanvasRect, 0.5f);
     }

--- a/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -94,6 +94,7 @@ MonoBehaviour:
   - RpcSetCommonReference
   - RpcSetSpecialReference
   - RpcSetHoopControllerReference
+  - RpcSetDeActivePlayerObject
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 플레이어가 과일 대포 맵의 골 콜라이더나, 점프 클럽의 데드존에 닿을 경우 프리팹이 비활성화 되도록 하였습니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 플레이어가 과일 대포 맵의 골 콜라이더나, 점프 클럽의 데드존에 닿을 경우 프리팹이 비활성화 되도록 하였습니다
> 이미 골인하거나 탈락한 플레이어는 더이상 남아있을 필요가 없기 때문에. 비활성화 처리 해주었습니다

# (선택)관련 이슈
- #290 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
