### PR TITLE
[Fix] PlayerObservedName UI 라운드가 끝나면 false 상태로 전환하기

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Scene/04_GameLoading/MapSelectionManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Scene/04_GameLoading/MapSelectionManager.cs
@@ -10,7 +10,7 @@ public class MapSelectionManager : MonoBehaviourPun
         }
     }
 
-    private int index = 1;
+    private int index = 2;
     private void SelectRandomMap()
     {
         if (PhotonNetwork.IsMasterClient)

--- a/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/ObservedPlayerNamePresenter.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/ObservedPlayerNamePresenter.cs
@@ -24,7 +24,6 @@ public class ObservedPlayerNamePresenter : Presenter
     protected override void OnUpdatedModel()
     {
         StageDataManager.Instance.IsGameActive
-            .Skip(1)
             .DistinctUntilChanged()
             .Subscribe(_ => SetActiveGameObject(false))
             .AddTo(_compositeDisposable);


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- 게임 플레이가 끝나면, 관전 UI가 false됩니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 게임 플레이가 끝나면, 관전 UI가 false됩니다
> 게임이 종료되면 관전 UI는 사라져야합니다
UniRx에 skip이 있었는데, 이를 해제하여 수정하였습니다

# (선택)스크린샷
<img width="657" alt="스크린샷 2023-07-07 오전 12 40 45" src="https://github.com/KIA-PROGRAMMING-38/JKC-FallguysProject/assets/120005202/c6feadd6-ed75-4b52-afca-a89c60f79334">

# (선택)관련 이슈
- #302 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
