### PR TITLE
[Fix] GameResult 씬에서의 승리/패배 에셋이 뜨지 않는 이슈 발생

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/UI/06_GameResult/GameResultFallGuyDataBinder.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/06_GameResult/GameResultFallGuyDataBinder.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using LiteralRepository;
 using Model;
-using ResourceRegistry;
 using UnityEngine;
 
 public class GameResultFallGuyDataBinder : MonoBehaviour

--- a/JKC_Fallguys/Assets/1_Scripts/UI/06_GameResult/ResultPresenter.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/06_GameResult/ResultPresenter.cs
@@ -26,11 +26,13 @@ public class ResultPresenter : Presenter
     /// </summary>
     protected override void OnUpdatedModel()
     {
-        ResultSceneModel.IsVictorious.Where(isVictorious => isVictorious == true)
+        ResultSceneModel.IsVictorious
+            .Where(isVictorious => isVictorious)
             .Subscribe(_ => LoadVictorySprite())
             .AddTo(_compositeDisposable);
         
-        ResultSceneModel.IsVictorious.Where(isVictorious => isVictorious == false)
+        ResultSceneModel.IsVictorious
+            .Where(isVictorious => !isVictorious)
             .Subscribe(_ => LoadLoseSprite())
             .AddTo(_compositeDisposable);
     }
@@ -38,13 +40,13 @@ public class ResultPresenter : Presenter
     private void LoadVictorySprite()
     {
         _resultView.ResultTextImage.sprite = 
-            Resources.Load<Sprite>(Path.Combine(PathLiteral.UI, PathLiteral.GameResult, PathLiteral.VictoryTextImage));
+            Resources.Load<Sprite>(Path.Combine(PathLiteral.Sprites, PathLiteral.UI, PathLiteral.GameResult, PathLiteral.VictoryTextImage));
     }
     
     private void LoadLoseSprite()
     {
         _resultView.ResultTextImage.sprite = 
-            Resources.Load<Sprite>(Path.Combine(PathLiteral.UI, PathLiteral.GameResult, PathLiteral.LoseTextImage));
+            Resources.Load<Sprite>(Path.Combine(PathLiteral.Sprites, PathLiteral.UI, PathLiteral.GameResult, PathLiteral.LoseTextImage));
     }
     
     public override void OnRelease()


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- ResultPresenter내의 리소스를 불러오는 경로를 수정했습니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- ResultPresenter내의 리소스를 불러오는 경로를 수정했습니다
> 폴더 구조가 변경되어, 리소스를 불러오는 코드도 수정하였습니다

# (선택)관련 이슈
- #371 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
