### PR TITLE
[Feat] Stage 씬에서 사용하는 RemainingTime UI 게임이 종료된다면 SetActive False 전환

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Manager/MapSelectionManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Manager/MapSelectionManager.cs
@@ -10,7 +10,7 @@ public class MapSelectionManager : MonoBehaviourPun
         }
     }
 
-    private int index = 1;
+    private int index = 2;
     private void SelectRandomMap()
     {
         if (PhotonNetwork.IsMasterClient)

--- a/JKC_Fallguys/Assets/1_Scripts/SceneInitializer/StageSceneInitializer.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/SceneInitializer/StageSceneInitializer.cs
@@ -9,8 +9,7 @@ public class StageSceneInitializer : SceneInitializer
 {
     protected override void InitializeData()
     {
-        StageSceneModel.InitializeCountDown();
-        
+        StageSceneModel.Clear();
         StageManager.Instance.Clear();
     }
 

--- a/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/RemainingTime/RemainingTimePresenter.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/RemainingTime/RemainingTimePresenter.cs
@@ -24,6 +24,12 @@ public class RemainingTimePresenter : Presenter
             .DistinctUntilChanged()
             .Subscribe(_ => SetReaminingTimeText())
             .AddTo(_compositeDisposable);
+        
+        StageManager.Instance.StageDataManager.IsGameActive
+            .Skip(1)
+            .Where(gameActive => !gameActive)
+            .Subscribe(_ => GameObjectHelper.SetActiveGameObject(_remainingTimeView.gameObject, false))
+            .AddTo(_compositeDisposable);
     }
 
     private void SetReaminingTimeText()

--- a/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/StageExitPanel/StageExitPanelPresenter.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/03_Stage/StageExitPanel/StageExitPanelPresenter.cs
@@ -1,7 +1,6 @@
 using Model;
 using Photon.Pun;
 using UniRx;
-using UnityEngine;
 
 public class StageExitPanelPresenter : Presenter
 {
@@ -16,23 +15,16 @@ public class StageExitPanelPresenter : Presenter
 
     protected override void OnOccuredUserEvent()
     {
-        // 계속하기 버튼을 눌렀을때 입니다.
         _stageExitPanelView.ResumeButton
             .OnClickAsObservable()
             .Subscribe(_ => StageSceneModel.SetExitPanelActive(false))
             .AddTo(_compositeDisposable);
-        
-        // 나가기 버튼을 눌렀을때 입니다.
+
         _stageExitPanelView.ExitButton
             .OnClickAsObservable()
             .Subscribe(_ => StageSceneModel.RoomAdmissionStatus(false))
             .AddTo(_compositeDisposable);
-        
-        _stageExitPanelView.ExitButton
-            .OnClickAsObservable()
-            .Subscribe(_ => Debug.Log(StageSceneModel.IsEnterPhotonRoom))
-            .AddTo(_compositeDisposable);
-    }
+        }
 
     protected override void OnUpdatedModel()
     {

--- a/JKC_Fallguys/Assets/1_Scripts/UI/05_RoundResult/RoundResultPresenter.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/05_RoundResult/RoundResultPresenter.cs
@@ -53,7 +53,6 @@ public class RoundResultPresenter : Presenter
     {
         for (int playerIndex = 0; playerIndex < RoundResultSceneModel.FallguyRankings.Count; ++playerIndex)
         {
-            Debug.Log($"PlayerIndex: {playerIndex}");
             if (playerIndex > 2)
                 break;
             

--- a/JKC_Fallguys/Assets/1_Scripts/UI/Model/StageSceneModel.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/UI/Model/StageSceneModel.cs
@@ -74,5 +74,13 @@ namespace Model
         {
             _observedPlayerActorName.Value = actorName;
         }
+
+        public static void Clear()
+        {
+            InitializeCountDown();
+            RoomAdmissionStatus(true);
+            SetExitPanelActive(false);
+            SetExitButtonActive(false);
+        }
     }
 }

--- a/JKC_Fallguys/Assets/Resources/Prefabs/UI/01_Lobby/Customization/CustomizationViewController.prefab
+++ b/JKC_Fallguys/Assets/Resources/Prefabs/UI/01_Lobby/Customization/CustomizationViewController.prefab
@@ -136,7 +136,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 2147483647
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &3873189831825509364
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1226,7 +1226,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 2147483647
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &3873189833343249973
 RectTransform:
   m_ObjectHideFlags: 0

--- a/JKC_Fallguys/Assets/Resources/Prefabs/UI/02_Matching/ExitMatchingPanelViewController.prefab
+++ b/JKC_Fallguys/Assets/Resources/Prefabs/UI/02_Matching/ExitMatchingPanelViewController.prefab
@@ -330,7 +330,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &7758790328902907276
 RectTransform:
   m_ObjectHideFlags: 0
@@ -854,7 +854,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &7758790329381874188
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1266,7 +1266,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &7758790329880633972
 RectTransform:
   m_ObjectHideFlags: 0

--- a/JKC_Fallguys/Assets/Resources/Prefabs/UI/03_Stage/StageExitPanelViewController.prefab
+++ b/JKC_Fallguys/Assets/Resources/Prefabs/UI/03_Stage/StageExitPanelViewController.prefab
@@ -443,7 +443,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &6777788423826315906
 RectTransform:
   m_ObjectHideFlags: 0
@@ -786,7 +786,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &6777788424173159682
 RectTransform:
   m_ObjectHideFlags: 0
@@ -1314,7 +1314,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!224 &6777788424806403450
 RectTransform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- RemainingTime UI가 게임이 끝날경우, SetActiveFalse되게 코드를 수정하였습니다

# (선택)스크린샷
<img width="745" alt="스크린샷 2023-07-11 오전 12 49 05" src="https://github.com/KIA-PROGRAMMING-38/JKC-FallguysProject/assets/120005202/ce1c738b-f147-425b-a042-068b32291ca8">

# (선택)관련 이슈
- #399 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
