### PR TITLE
[FIx] HoopLegend 맵에서 서브 클라이언트가 후프를 넘어도, 동기화가 되지 않는 현상 수정

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Manager/MapSelectionManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Manager/MapSelectionManager.cs
@@ -10,7 +10,7 @@ public class MapSelectionManager : MonoBehaviourPun
         }
     }
 
-    private int index = 0;
+    private int index = 1;
     private void SelectRandomMap()
     {
         if (PhotonNetwork.IsMasterClient)

--- a/JKC_Fallguys/Assets/1_Scripts/Photon/PhotonStageSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Photon/PhotonStageSceneRoomManager.cs
@@ -108,7 +108,6 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
             .AddTo(this);
     }
 
-
     private void StageDontDestroyOnLoadSet()
     {
         DontDestroyOnLoad(gameObject);
@@ -233,8 +232,7 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
                     int oldScore = playerData.Score;
                     int newScore = oldScore + 2500;
                     playerData.Score = newScore;
-                    StageManager.Instance.PlayerContainer.PlayerDataByIndex[playerIndex] =
-                        playerData; // Updated PlayerData back to dictionary
+                    StageManager.Instance.PlayerContainer.PlayerDataByIndex[playerIndex] = playerData;
                 }
             }
         }
@@ -256,8 +254,7 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
                     int prevScore = playerData.Score;
                     int updatedScore = prevScore + rankRewards[i];
                     playerData.Score = updatedScore;
-                    StageManager.Instance.PlayerContainer.PlayerDataByIndex[playerIndex] =
-                        playerData; // Updated PlayerData back to dictionary
+                    StageManager.Instance.PlayerContainer.PlayerDataByIndex[playerIndex] = playerData;
                 }
             }
         }

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/CommonHoop.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/CommonHoop.cs
@@ -52,16 +52,10 @@ public class CommonHoop : MonoBehaviourPun
 
     private void Start()
     {
+        _hoopController = StageManager.Instance.ObjectRepository.transform.Find("MapHoopLegend(Clone)").GetComponentInChildren<HoopController>();
+        
         _goalCheck.OnPlayerEnter += HandlePlayerEnter;
         _goalCheck.OnPlayerExit += HandlePlayerExit;
-        
-        photonView.RPC("RpcSetHoopControllerReference", RpcTarget.AllBuffered);
-    }
-
-    [PunRPC]
-    public void RpcSetHoopControllerReference()
-    {
-        _hoopController = StageManager.Instance.ObjectRepository.transform.Find("MapHoopLegend(Clone)").GetComponentInChildren<HoopController>();
     }
     
     private void HandlePlayerEnter()
@@ -69,11 +63,17 @@ public class CommonHoop : MonoBehaviourPun
         if (!_playerEntered && !_isMoving)
         {
             _playerEntered = true;
-            ParticlePlay().Forget();
-            PropellerAnimation(_cancelToken).Forget();
-            
             _hoopController.PlayerPassesHoop(1);
+            
+            photonView.RPC("RpcHandlePlayerEnter", RpcTarget.AllBuffered);
         }
+    }
+
+    [PunRPC]
+    public void RpcHandlePlayerEnter()
+    {
+        ParticlePlay().Forget();
+        PropellerAnimation(_cancelToken).Forget();
     }
 
     private async UniTaskVoid ParticlePlay()

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/SpecialHoop.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/SpecialHoop.cs
@@ -52,16 +52,10 @@ public class SpecialHoop : MonoBehaviourPun
 
     private void Start()
     {
+        _hoopController = StageManager.Instance.ObjectRepository.transform.Find("MapHoopLegend(Clone)").GetComponentInChildren<HoopController>();
+        
         _goalCheck.OnPlayerEnter += HandlePlayerEnter;
         _goalCheck.OnPlayerExit += HandlePlayerExit;
-        
-        photonView.RPC("RpcSetHoopControllerReference", RpcTarget.AllBuffered);
-    }
-    
-    [PunRPC]
-    public void RpcSetHoopControllerReference()
-    {
-        _hoopController = StageManager.Instance.ObjectRepository.transform.Find("MapHoopLegend(Clone)").GetComponentInChildren<HoopController>();
     }
 
     private void HandlePlayerEnter()
@@ -69,11 +63,17 @@ public class SpecialHoop : MonoBehaviourPun
         if (!_playerEntered && !_isMoving)
         {
             _playerEntered = true;
-            ParticlePlay().Forget();
-            PropellerAnimation(_cancelToken).Forget();
-            
             _hoopController.PlayerPassesHoop(2);
+            
+            photonView.RPC("RpcHandlePlayerEnter", RpcTarget.AllBuffered);
         }
+    }
+
+    [PunRPC]
+    public void RpcHandlePlayerEnter()
+    {
+        ParticlePlay().Forget();
+        PropellerAnimation(_cancelToken).Forget();
     }
     
     private async UniTaskVoid ParticlePlay()

--- a/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/JKC_Fallguys/Assets/Plugins/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -107,6 +107,7 @@ MonoBehaviour:
   - RpcSyncServerTime
   - RpcAddFailedPlayer
   - RpcUpdateStageDataOnAllClients
+  - RpcHandlePlayerEnter
   DisableAutoOpenWizard: 1
   ShowSettings: 1
   DevRegionSetOnce: 1


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- HoopLegend 맵에서 서브 클라이언트가 후프를 넘어도, 동기화가 되지 않는 현상을 수정하였습니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- 후프를 통과할 경우 RpcHandlePlayerEnter를 호출하도록 하였습니다
> 후프의 행동을 실행하는 함수를 Rpc로 모든 클라이언트에게 전송하여 행동을 수행하게 만들었습니다

# (선택)스크린샷


# (선택)관련 이슈
- #418 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
