### PR TITLE
[Fix] HoopLegend 맵에서 게임을 플레이 한 뒤, 점수 업데이트가 마스터 클라이언트만 되는 현상 수정

### DIFF
--- a/JKC_Fallguys/Assets/1_Scripts/Photon/PhotonStageSceneRoomManager.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Photon/PhotonStageSceneRoomManager.cs
@@ -284,7 +284,8 @@ public class PhotonStageSceneRoomManager : MonoBehaviourPun
         string playerScoresByIndexJson =
             JsonConvert.SerializeObject(StageManager.Instance.PlayerContainer.PlayerDataByIndex);
 
-        photonView.RPC("RpcUpdateStageDataOnAllClients", RpcTarget.All, playerScoresByIndexJson,
+        photonView.RPC("RpcUpdateStageDataOnAllClients", RpcTarget.All, 
+            playerScoresByIndexJson,
             StageManager.Instance.PlayerContainer.CachedPlayerIndicesForResults.ToArray(),
             StageManager.Instance.PlayerContainer.StagePlayerRankings.ToArray());
     }

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/FruitChute/FruitChuteGoalCollider.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/FruitChute/FruitChuteGoalCollider.cs
@@ -33,7 +33,6 @@ public class FruitChuteGoalCollider : MonoBehaviourPun
     [PunRPC]
     public void RpcUpdatePlayerRanking(int playerIndex)
     {
-        // Each client updates their own ranking list through this function.
         PlayerContainer playerContainer = StageManager.Instance.PlayerContainer;
 
         playerContainer.AddPlayerToRanking(playerIndex);

--- a/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/HoopController.cs
+++ b/JKC_Fallguys/Assets/1_Scripts/Stage/HoopLegend/HoopController.cs
@@ -23,8 +23,6 @@ public class HoopController : MonoBehaviourPun
         }
     }
 
-    private CommonHoop _commonHoop;
-    private SpecialHoop _specialHoop;
     private void InitializeObject()
     {
         ObjectTransforms commonHoopData = ResourceManager.JsonLoader<ObjectTransforms>($"Data/CommonHoopTransformData");
@@ -85,18 +83,9 @@ public class HoopController : MonoBehaviourPun
     {
         if (PhotonNetwork.IsMasterClient)
         {
-            // 플레이어의 후프 카운트가 아직 Dictionary에 없다면, 먼저 0으로 초기화합니다.
-            if (!_playerHoopCounts.ContainsKey(actorNumber))
-            {
-                _playerHoopCounts[actorNumber] = 0;
-            }
-
-            // 해당 플레이어의 키에 대응하여 값을 증가시킵니다.
-            _playerHoopCounts[actorNumber] += increaseValue;
+            // 모든 클라이언트의 플레이어 후프 카운트를 갱신합니다.
+            photonView.RPC("UpdateHoopCount", RpcTarget.All, actorNumber, increaseValue);
         }
-
-        // 모든 클라이언트의 플레이어 후프 카운트를 갱신합니다.
-        photonView.RPC("UpdateHoopCount", RpcTarget.All, actorNumber, _playerHoopCounts[actorNumber]);
     }
 
     /// <summary>
@@ -104,15 +93,22 @@ public class HoopController : MonoBehaviourPun
     /// 변경된 카운트를 자신의 로컬 _playerHoopCounts Dictionary에 업데이트합니다.
     /// </summary>
     [PunRPC]
-    public void UpdateHoopCount(int actorNumber, int newCount)
+    public void UpdateHoopCount(int actorNumber, int increaseValue)
     {
-        _playerHoopCounts[actorNumber] = newCount;
+        // 플레이어의 후프 카운트가 아직 Dictionary에 없다면, 먼저 0으로 초기화합니다.
+        if (!_playerHoopCounts.ContainsKey(actorNumber))
+        {
+            _playerHoopCounts[actorNumber] = 0;
+        }
+
+        // 해당 플레이어의 키에 대응하여 값을 증가시킵니다.
+        _playerHoopCounts[actorNumber] += increaseValue;
     }
 
     /// <summary>
     /// 플레이어가 후프를 지나가면 호출됩니다.
     /// 자신의 ActorNumber와 Value를 HoopController.IncreaseCountAndBroadcast 메서드에 전달합니다.
-    /// </summary>
+    /// </summary> 
     /// <param name="value">플레이어가 획득한 점수입니다..</param>
     public void PlayerPassesHoop(int value)
     {


### PR DESCRIPTION
# PR을 하기 전 체크사항
- [x] 임시로 작성한 코드는 모두 제거했나요?
- [x] 주석은 충분히 작성했나요?
- [x] 실행했을 때, 오류는 없나요?
- [x] 커밋 메시지는 [가이드](https://docs.google.com/document/d/1bDgWctGEprMvLzV5OpuZV1-BCnrhVVJ19cd8D9tFArU/edit#heading=h.jgj6vfjils4q)에 맞춰 작성됐나요?

# 변경된 기능
- HoopLegend 맵에서 후프를 넘을 경우 점수를 기록하는 Dictionary가 마스터 클라이언트에서만 업데이트 되고 있었습니다
- 이를 수정하여, 모든 클라이언트에서 업데이트 하도록 변경하였습니다

# 제안 사항
위의 기능을 달성하기 위해 프로젝트에 어떤 변화를 주었는지 작성합니다.

- HoopController 클래스를 수정하였습니다
> 후프를 넘을 경우 처리되는 로직이, 해당 클래스에 있습니다
기존의 로직은, 마스터 클라이언트가 플레이어당 넘은 후프 점수를 기록하는 딕셔너리를 기록하고, 이를 퍼뜨렸는데
변경된 로직은 모든클라이언트에서 특정한 값을 가지고 업데이트 하도록, 마스터 클라이언트가 브로드캐스트합니다

# (선택)스크린샷
![화면_기록_2023-07-11_오후_6_20_21_AdobeExpress](https://github.com/KIA-PROGRAMMING-38/JKC-FallguysProject/assets/120005202/50e65ad4-1c61-4a34-9d8f-c3e556084308)

# (선택)관련 이슈
- #414 

---

# 코드 리뷰 가이드
코드 리뷰를 어떻게 해야하는지 모르겠다면 아래의 사항을 고려해보세요.

- 이름은 충분히 명확한가?
- 코드 흐름은 읽기 쉽게 되어 있는가?
  - 개행은 세부 로직 별로 잘 적용이 되어 있는가?
- 불필요한 객체가 존재하진 않는가?
  - 쓸데없는 Manager 객체가 존재하진 않는가?
- 객체 간 결합도는 충분히 낮은가?
- 불필요한 필드가 존재하진 않는가?
- 다른 객체를 참조할 때, Find()를 사용하고 있진 않은가?
  - Instantiate()를 활용해 참조를 얻어올 수 있진 않은가?
  - 전역적인 접근점을 지닌 다른 객체를 통해서 참조를 얻어올 수 있진 않은가?
- 과도하게 모듈화 되어 있진 않은가?
  - 하나의 함수로 작성할 수 있는 걸 구태여 여러 개로 분리하진 않았는가?
- [주석이 작성되어 있는가?](https://learn.microsoft.com/ko-kr/dotnet/csharp/language-reference/xmldoc/recommended-tags)
  - 모든 public 함수에 주석이 작성되어 있는가?
  - 코드만으로는 이해하기 어려운 부분에 주석이 작성되어 있는가?
- 함수는 하나의 일만 해결하고 있는가?
- Assert()로 사전 조건과 사후 조건을 모두 체크하고 있는가?
  - NullReferenceException이 발생할 만한 부분은 없는가?
